### PR TITLE
Update the ANDROID client params

### DIFF
--- a/InnerTube/InnerTube.cs
+++ b/InnerTube/InnerTube.cs
@@ -138,7 +138,7 @@ public class InnerTube
 			.AddValue("racyCheckOk", contentCheckOk);
 
 		if (client == RequestClient.ANDROID)
-			postData.AddValue("params", "CgIQBg");
+			postData.AddValue("params", "CgIIAdgDAQ%3D%3D");
 
 		return await MakeRequest(client, "player", postData,
 			language, region, true);

--- a/InnerTube/InnerTube.cs
+++ b/InnerTube/InnerTube.cs
@@ -59,13 +59,13 @@ public class InnerTube
 		hrm.Headers.Add("X-Youtube-Client-Version", client switch
 		{
 			RequestClient.WEB => "2.20220809.02.00",
-			RequestClient.ANDROID => "17.31.4",
-			RequestClient.IOS => "17.31.4",
+			RequestClient.ANDROID => "19.09.4",
+			RequestClient.IOS => "19.09.4",
 			var _ => ""
 		});
 		hrm.Headers.Add("Origin", "https://www.youtube.com");
 		if (client == RequestClient.ANDROID)
-			hrm.Headers.Add("User-Agent", "com.google.android.youtube/17.31.35 (Linux; U; Android 11) gzip");
+			hrm.Headers.Add("User-Agent", "com.google.android.youtube/19.09.4 (Linux; U; Android 11) gzip");
 
 		HttpResponseMessage ytPlayerRequest = await HttpClient.SendAsync(hrm);
 		if (!ytPlayerRequest.IsSuccessStatusCode)

--- a/InnerTube/InnerTube.csproj
+++ b/InnerTube/InnerTube.csproj
@@ -10,8 +10,8 @@
         <PackageLicenseUrl>https://github.com/kuylar/InnerTube/blob/master/LICENSE</PackageLicenseUrl>
         <RepositoryUrl>https://github.com/kuylar/InnerTube</RepositoryUrl>
         <PackageTags>youtube, innertube</PackageTags>
-        <AssemblyVersion>1.1.2</AssemblyVersion>
-        <Version>1.1.2</Version>
+        <AssemblyVersion>1.1.3</AssemblyVersion>
+        <Version>1.1.3</Version>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <!-- Remove/comment this while looking for missing XMLDocs -->
         <NoWarn>$(NoWarn);1591</NoWarn>

--- a/InnerTube/InnerTube.csproj
+++ b/InnerTube/InnerTube.csproj
@@ -10,8 +10,8 @@
         <PackageLicenseUrl>https://github.com/kuylar/InnerTube/blob/master/LICENSE</PackageLicenseUrl>
         <RepositoryUrl>https://github.com/kuylar/InnerTube</RepositoryUrl>
         <PackageTags>youtube, innertube</PackageTags>
-        <AssemblyVersion>1.1.1</AssemblyVersion>
-        <Version>1.1.1</Version>
+        <AssemblyVersion>1.1.2</AssemblyVersion>
+        <Version>1.1.2</Version>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <!-- Remove/comment this while looking for missing XMLDocs -->
         <NoWarn>$(NoWarn);1591</NoWarn>

--- a/InnerTube/InnerTubeRequest.cs
+++ b/InnerTube/InnerTubeRequest.cs
@@ -35,12 +35,12 @@ internal class InnerTubeRequest
 				break;
 			case RequestClient.ANDROID:
 				clientContext.Add("clientName", "ANDROID");
-				clientContext.Add("clientVersion", "17.31.35");
+				clientContext.Add("clientVersion", "19.09.4");
 				clientContext.Add("osName", "Android");
 				clientContext.Add("osVersion", "11");
 				clientContext.Add("androidSdkVersion", 30);
 				clientContext.Add("platform", "MOBILE");
-				clientContext.Add("userAgent", "com.google.android.youtube/17.31.35 (Linux; U; Android 11) gzip");
+				clientContext.Add("userAgent", "com.google.android.youtube/19.09.4 (Linux; U; Android 11) gzip");
 				break;
 			case RequestClient.IOS:
 				clientContext.Add("clientName", "IOS");


### PR DESCRIPTION
# Details
Temporary bypass while I work on a JavaScript interpreter to descramble nparam & signatures (found [here](https://github.com/kuylar/InnerTube/tree/1.0.28)). I was gonna push that instead but I'm getting SSL errors on some videos so I decided to push this for now